### PR TITLE
fix: move colors_name assignment after hi clear to prevent it being reset to nil

### DIFF
--- a/lua/Eva-Theme.lua
+++ b/lua/Eva-Theme.lua
@@ -56,17 +56,15 @@ end
 function M.colorscheme(variant)
   variant = variant or 'dark'
 
-  vim.g.colors_name = variant_name(variant)
-
   vim.opt.termguicolors = true
   vim.o.background = U.is_dark(variant) and 'dark' or 'light'
 
   vim.cmd('set cursorline')
 
-  if vim.g.colors_name then
-    vim.cmd('hi clear')
-    vim.cmd('syntax reset')
-  end
+  vim.cmd('hi clear')
+  vim.cmd('syntax reset')
+
+  vim.g.colors_name = variant_name(variant)
 
   local P = require('Eva-Theme.palette')
   local H = require('Eva-Theme.highlight')


### PR DESCRIPTION
## Problem

`vim.cmd('hi clear')` resets `vim.g.colors_name` to `nil` in Neovim/Vim (documented at `:help hi-clear`). The `colorscheme()` function previously assigned `vim.g.colors_name` **before** calling `hi clear`, causing it to be immediately cleared.

This broke downstream consumers that read `vim.g.colors_name` after `:colorscheme` — for example, huez.nvim's `colorscheme_exists()` function tries to restore the previous colorscheme via `vim.cmd.colorscheme(vim.g.colors_name)`, which becomes `vim.cmd.colorscheme(nil)` → `:colorscheme default`, causing **"default"** to appear in the command line.

## Fix

Move `vim.g.colors_name = variant_name(variant)` to **after** `hi clear` / `syntax reset`, following the standard Vim colorscheme pattern (see `:help colorscheme`).

## Before / After

```diff
 function M.colorscheme(variant)
   variant = variant or 'dark'
 
-  vim.g.colors_name = variant_name(variant)
-
   vim.opt.termguicolors = true
   vim.o.background = U.is_dark(variant) and 'dark' or 'light'
 
   vim.cmd('set cursorline')
 
-  if vim.g.colors_name then
-    vim.cmd('hi clear')
-    vim.cmd('syntax reset')
-  end
+  vim.cmd('hi clear')
+  vim.cmd('syntax reset')
+
+  vim.g.colors_name = variant_name(variant)
 
   ...
 end
```

Note: the `if vim.g.colors_name then` guard was also removed — since `colors_name` is no longer set before the `hi clear` call, the guard would always be falsy and `hi clear` would always execute.